### PR TITLE
Updating group management + some Dashboard & navigation improvements

### DIFF
--- a/app/components/dashboard-shell.tsx
+++ b/app/components/dashboard-shell.tsx
@@ -35,6 +35,7 @@ const menuRoutes: Record<string, string> = {
 	"5": "/meal-plan",
 };
 
+const menuItems: MenuItem[] = [
 	{ key: "1", icon: <AppstoreOutlined />, label: "Dashboard" },
 	{ key: "2", icon: <ShoppingOutlined />, label: "Pantry" },
 	{ key: "3", icon: <FileTextOutlined />, label: "Shopping List" },

--- a/app/components/dashboard-shell.tsx
+++ b/app/components/dashboard-shell.tsx
@@ -6,7 +6,6 @@ import {
 	CalendarOutlined,
 	FileTextOutlined,
 	LeftOutlined,
-	ReadOutlined,
 	RightOutlined,
 	ShoppingOutlined,
 } from "@ant-design/icons";
@@ -36,7 +35,6 @@ const menuRoutes: Record<string, string> = {
 	"5": "/meal-plan",
 };
 
-const menuItems: MenuItem[] = [
 	{ key: "1", icon: <AppstoreOutlined />, label: "Dashboard" },
 	{ key: "2", icon: <ShoppingOutlined />, label: "Pantry" },
 	{ key: "3", icon: <FileTextOutlined />, label: "Shopping List" },

--- a/app/components/dashboard-shell.tsx
+++ b/app/components/dashboard-shell.tsx
@@ -33,7 +33,6 @@ const menuRoutes: Record<string, string> = {
 	"1": "/dashboard",
 	"2": "/pantry",
 	"3": "/shopping-lists",
-	"4": "/recipes",
 	"5": "/meal-plan",
 };
 
@@ -41,7 +40,6 @@ const menuItems: MenuItem[] = [
 	{ key: "1", icon: <AppstoreOutlined />, label: "Dashboard" },
 	{ key: "2", icon: <ShoppingOutlined />, label: "Pantry" },
 	{ key: "3", icon: <FileTextOutlined />, label: "Shopping List" },
-	{ key: "4", icon: <ReadOutlined />, label: "Recipes" },
 	{ key: "5", icon: <CalendarOutlined />, label: "Meal Plan" },
 ];
 

--- a/app/components/page-header.tsx
+++ b/app/components/page-header.tsx
@@ -56,7 +56,10 @@ export default function PageHeader({ title }: PageHeaderProps) {
 	return (
 		<header className="border-b border-gray-200 bg-white">
 			<div className="mx-auto grid h-16 w-full max-w-7xl grid-cols-[1fr_auto_1fr] items-center px-6">
-				<div className="flex items-center gap-3">
+				<div
+					className="flex cursor-pointer items-center gap-3 transition-opacity hover:opacity-80"
+					onClick={() => router.push("/dashboard")}
+				>
 					<div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-100">
 						<Image alt="PlateMate logo" height={20} src="/favicon.svg" width={20} />
 					</div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -32,7 +32,7 @@ const Dashboard: React.FC = () => {
 				try {
 					const pantryData = await apiService.get<PantryGetDTO>("/groups/me/pantry");
 					setPantry(pantryData);
-				} catch (err) {
+				} catch {
 					console.debug("No pantry found, likely not in a group yet.");
 					setPantry(null);
 				}
@@ -40,13 +40,13 @@ const Dashboard: React.FC = () => {
 				try {
 					const shoppingListData = await apiService.get<ShoppingListGetDTO>("/groups/me/shopping-list");
 					setShoppingList(shoppingListData);
-				} catch (err) {
+				} catch {
 					console.debug("No shopping list found, likely not in a group yet.");
 					setShoppingList(null);
 				}
 
-			} catch (err) {
-				setError(err instanceof Error ? err.message : "Failed to load profile data");
+			} catch {
+				setError("Failed to load profile data");
 			} finally {
 				setIsLoading(false);
 			}
@@ -74,7 +74,7 @@ const Dashboard: React.FC = () => {
 				<Title level={2} style={{ margin: 0, color: "#0f172a" }}>
 					Good morning, {user?.username ?? "Chef"}
 				</Title>
-				<Text className="text-secondary-600">Welcome to your kitchen. Here's your current status.</Text>
+				<Text className="text-secondary-600">Welcome to your kitchen. Here&apos;s your current status.</Text>
 			</div>
 
 			{error && (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,23 +1,139 @@
 "use client";
 
-import React from "react";
-import { Typography } from "antd";
+import React, { useEffect, useState } from "react";
+import { Typography, Row, Col, Card, Statistic, Spin, Alert } from "antd";
+import { ShoppingOutlined, FileTextOutlined, UserOutlined } from "@ant-design/icons";
 import DashboardShell from "@/components/dashboard-shell";
+import { useApi } from "@/hooks/useApi";
+import { User } from "@/types/user";
+import { PantryGetDTO } from "@/types/pantry";
+import { ShoppingListGetDTO } from "@/types/shopping-list";
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 const Dashboard: React.FC = () => {
-	const userName = "Name";
+	const apiService = useApi();
+	const [user, setUser] = useState<User | null>(null);
+	const [pantry, setPantry] = useState<PantryGetDTO | null>(null);
+	const [shoppingList, setShoppingList] = useState<ShoppingListGetDTO | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const fetchDashboardData = async () => {
+			setIsLoading(true);
+			setError(null);
+			try {
+				// Fetch user separately as it's core to the identity
+				const userData = await apiService.get<User>("/users/me");
+				setUser(userData);
+
+				// Fetch group-dependent data, but handle "not in group" (404) gracefully
+				try {
+					const pantryData = await apiService.get<PantryGetDTO>("/groups/me/pantry");
+					setPantry(pantryData);
+				} catch (err) {
+					console.debug("No pantry found, likely not in a group yet.");
+					setPantry(null);
+				}
+
+				try {
+					const shoppingListData = await apiService.get<ShoppingListGetDTO>("/groups/me/shopping-list");
+					setShoppingList(shoppingListData);
+				} catch (err) {
+					console.debug("No shopping list found, likely not in a group yet.");
+					setShoppingList(null);
+				}
+
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Failed to load profile data");
+			} finally {
+				setIsLoading(false);
+			}
+		};
+
+		fetchDashboardData();
+	}, [apiService]);
+
+	const pantryItemCount = pantry?.items?.length ?? 0;
+	const shoppingListItemCount = (shoppingList?.items ?? shoppingList?.shoppingListItems ?? []).filter(item => !item.isBought).length;
+
+	if (isLoading) {
+		return (
+			<DashboardShell headerTitle="Dashboard" selectedMenuKey="1">
+				<div className="flex items-center justify-center py-20">
+					<Spin size="large" description="Preparing your kitchen dashboard..." />
+				</div>
+			</DashboardShell>
+		);
+	}
 
 	return (
 		<DashboardShell headerTitle="Dashboard" selectedMenuKey="1">
 			<div style={{ marginBottom: "32px" }}>
 				<Title level={2} style={{ margin: 0, color: "#0f172a" }}>
-					Good morning, {userName}
+					Good morning, {user?.username ?? "Chef"}
 				</Title>
+				<Text className="text-secondary-600">Welcome to your kitchen. Here's your current status.</Text>
 			</div>
 
-			<div className="dashboard-grid">{/* Quick Actions, Upcoming, etc. */}</div>
+			{error && (
+				<Alert
+					message="Connection Issue"
+					description="There was a problem reaching the server. Please check your connection."
+					type="warning"
+					showIcon
+					className="mb-8 rounded-2xl"
+				/>
+			)}
+
+			<Row gutter={[24, 24]}>
+				<Col xs={24} sm={12} lg={8}>
+					<Card className="rounded-3xl border border-primary-200 bg-white/90 shadow-sm transition-all hover:shadow-md">
+						<Statistic
+							title={<span className="text-lg font-medium text-slate-600">Pantry Stock</span>}
+							value={pantryItemCount}
+							prefix={<ShoppingOutlined className="mr-2 text-primary-500" />}
+							suffix="Items"
+							styles={{ content: { color: "#f97316", fontWeight: "bold" } }}
+						/>
+						<div className="mt-4 border-t border-slate-100 pt-4">
+							<Text className="text-xs text-slate-500">
+								{!pantry ? "Join a group to start tracking your stock." : "View and manage your current ingredients."}
+							</Text>
+						</div>
+					</Card>
+				</Col>
+				<Col xs={24} sm={12} lg={8}>
+					<Card className="rounded-3xl border border-primary-200 bg-white/90 shadow-sm transition-all hover:shadow-md">
+						<Statistic
+							title={<span className="text-lg font-medium text-slate-600">Shopping List</span>}
+							value={shoppingListItemCount}
+							prefix={<FileTextOutlined className="mr-2 text-primary-500" />}
+							suffix="To Buy"
+							styles={{ content: { color: "#f97316", fontWeight: "bold" } }}
+						/>
+						<div className="mt-4 border-t border-slate-100 pt-4">
+							<Text className="text-xs text-slate-500">
+								{!shoppingList ? "Your grocery list will appear here once you're in a group." : "Items remaining on your grocery list."}
+							</Text>
+						</div>
+					</Card>
+				</Col>
+				<Col xs={24} sm={12} lg={8}>
+					<Card className="rounded-3xl border border-primary-200 bg-white/90 shadow-sm transition-all hover:shadow-md">
+						<Statistic
+							title={<span className="text-lg font-medium text-slate-600">Kitchen Profile</span>}
+							value={user?.username ?? "Active"}
+							prefix={<UserOutlined className="mr-2 text-primary-500" />}
+							styles={{ content: { color: "#f97316", fontWeight: "bold", fontSize: "1.5rem" } }}
+						/>
+						<div className="mt-4 border-t border-slate-100 pt-4">
+							<Text className="text-xs text-slate-500">Your individual profile is ready.</Text>
+						</div>
+					</Card>
+				</Col>
+			</Row>
 		</DashboardShell>
 	);
 };

--- a/app/groups/me/page.tsx
+++ b/app/groups/me/page.tsx
@@ -16,20 +16,7 @@ import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import PageHeader from "@/components/page-header";
 
-interface GroupMember {
-	id?: number;
-	userId?: string;
-	username?: string;
-	name?: string;
-}
-
-interface GroupMeResponse {
-	id?: number;
-	name?: string;
-	inviteCode?: string;
-	createdAt?: string;
-	members?: GroupMember[];
-}
+const { Text, Title } = Typography;
 
 export default function GroupMePage() {
 	const apiService = useApi();

--- a/app/groups/me/page.tsx
+++ b/app/groups/me/page.tsx
@@ -14,11 +14,22 @@ import {
 } from "@ant-design/icons";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
-import DashboardShell from "@/components/dashboard-shell";
-import { Group, GroupRole } from "@/types/group";
-import { User } from "@/types/user";
+import PageHeader from "@/components/page-header";
 
-const { Text, Title } = Typography;
+interface GroupMember {
+	id?: number;
+	userId?: string;
+	username?: string;
+	name?: string;
+}
+
+interface GroupMeResponse {
+	id?: number;
+	name?: string;
+	inviteCode?: string;
+	createdAt?: string;
+	members?: GroupMember[];
+}
 
 export default function GroupMePage() {
 	const apiService = useApi();
@@ -36,14 +47,16 @@ export default function GroupMePage() {
 	const isAdmin = group?.members?.find((m) => m.userID === currentUser?.id)?.role === GroupRole.ADMIN;
 
 	useEffect(() => {
-		if (typeof window === "undefined") return;
+		if (typeof window === "undefined") {
+			return;
+		}
 		const params = new URLSearchParams(window.location.search);
 		if (params.get("joined") === "1") {
 			setJoinedMessage(`You successfully joined ${params.get("groupName") ?? "the group"}.`);
 		}
 	}, []);
 
-	const fetchData = async () => {
+	const fetchData = useCallback(async () => {
 		setIsLoading(true);
 		setErrorMessage("");
 		try {
@@ -63,11 +76,11 @@ export default function GroupMePage() {
 		} finally {
 			setIsLoading(false);
 		}
-	};
+	}, [apiService]);
 
 	useEffect(() => {
 		fetchData();
-	}, [apiService]);
+	}, [fetchData]);
 
 	const handleCopyInviteCode = () => {
 		if (group?.inviteCode) {
@@ -88,7 +101,7 @@ export default function GroupMePage() {
 			setGroup(updated);
 			setIsEditingName(false);
 			message.success("Group renamed successfully!");
-		} catch (error) {
+		} catch {
 			message.error("Failed to rename group.");
 		} finally {
 			setIsSubmitting(false);
@@ -108,7 +121,7 @@ export default function GroupMePage() {
 					const updated = await apiService.post<Group>("/groups/me/invite-code", {});
 					setGroup(updated);
 					message.success("Invite code regenerated!");
-				} catch (error) {
+				} catch {
 					message.error("Failed to regenerate code.");
 				}
 			},
@@ -148,7 +161,7 @@ export default function GroupMePage() {
 					await apiService.delete("/groups/me");
 					message.success("Group deleted.");
 					router.push("/groups");
-				} catch (error) {
+				} catch {
 					message.error("Failed to delete group.");
 				}
 			},
@@ -156,8 +169,9 @@ export default function GroupMePage() {
 	};
 
 	return (
-		<DashboardShell headerTitle="Group Management" selectedMenuKey="6">
-			<div className="flex flex-col items-center">
+		<div className="flex min-h-screen flex-col bg-gradient-to-b from-orange-50 to-white">
+			<PageHeader title="Group Management" />
+			<div className="flex flex-1 flex-col items-center px-4 py-8">
 				<Card className="w-full max-w-2xl rounded-[2rem] border border-primary-500/20 bg-white/90 shadow-xl backdrop-blur">
 					{joinedMessage ? <Alert className="mb-6" message={joinedMessage} showIcon type="success" /> : null}
 
@@ -260,11 +274,10 @@ export default function GroupMePage() {
 									{group.members?.map((member) => (
 										<div
 											key={member.userID}
-											className={`flex items-center justify-between rounded-xl border p-3 ${
-												member.userID === currentUser?.id
-													? "border-primary-300 bg-primary-50"
-													: "border-slate-100 bg-white"
-											}`}
+											className={`flex items-center justify-between rounded-xl border p-3 ${member.userID === currentUser?.id
+												? "border-primary-300 bg-primary-50"
+												: "border-slate-100 bg-white"
+												}`}
 										>
 											<div className="flex items-center gap-2">
 												<div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200">
@@ -319,7 +332,7 @@ export default function GroupMePage() {
 					)}
 				</Card>
 			</div>
-		</DashboardShell>
+		</div>
 	);
 }
 

--- a/app/groups/me/page.tsx
+++ b/app/groups/me/page.tsx
@@ -1,112 +1,323 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Alert, Card, Spin } from "antd";
+import { Alert, Button, Card, Divider, Input, Modal, Space, Spin, Tag, Tooltip, Typography, message } from "antd";
+import {
+	CopyOutlined,
+	DeleteOutlined,
+	EditOutlined,
+	ExclamationCircleOutlined,
+	InfoCircleOutlined,
+	LogoutOutlined,
+	ReloadOutlined,
+	UserOutlined,
+} from "@ant-design/icons";
+import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import PageHeader from "@/components/page-header";
+import { Group, GroupRole } from "@/types/group";
+import { User } from "@/types/user";
 
-interface GroupMember {
-	id?: number;
-	userId?: string;
-	username?: string;
-	name?: string;
-}
-
-interface GroupMeResponse {
-	id?: number;
-	name?: string;
-	inviteCode?: string;
-	createdAt?: string;
-	members?: GroupMember[];
-}
+const { Text, Title } = Typography;
 
 export default function GroupMePage() {
 	const apiService = useApi();
-	const [group, setGroup] = useState<GroupMeResponse | null>(null);
+	const router = useRouter();
+	const [group, setGroup] = useState<Group | null>(null);
+	const [currentUser, setCurrentUser] = useState<User | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [errorMessage, setErrorMessage] = useState<string>("");
 	const [joinedMessage, setJoinedMessage] = useState("");
 
+	const [isEditingName, setIsEditingName] = useState(false);
+	const [newGroupName, setNewGroupName] = useState("");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const isAdmin = group?.members?.find((m) => m.userID === currentUser?.id)?.role === GroupRole.ADMIN;
+
 	useEffect(() => {
-		if (typeof window === "undefined") {
-			return;
-		}
+		if (typeof window === "undefined") return;
 		const params = new URLSearchParams(window.location.search);
 		if (params.get("joined") === "1") {
 			setJoinedMessage(`You successfully joined ${params.get("groupName") ?? "the group"}.`);
 		}
 	}, []);
 
-	useEffect(() => {
-		const fetchGroup = async () => {
-			setIsLoading(true);
-			setErrorMessage("");
-			try {
-				const data = await apiService.get<GroupMeResponse>("/groups/me");
-				setGroup(data);
-			} catch (error) {
-				if (error instanceof Error) {
-					setErrorMessage(error.message);
-				} else {
-					setErrorMessage("Could not load your group data.");
-				}
-			} finally {
-				setIsLoading(false);
+	const fetchData = async () => {
+		setIsLoading(true);
+		setErrorMessage("");
+		try {
+			const [groupData, userData] = await Promise.all([
+				apiService.get<Group>("/groups/me"),
+				apiService.get<User>("/users/me"),
+			]);
+			setGroup(groupData);
+			setCurrentUser(userData);
+			setNewGroupName(groupData.name || "");
+		} catch (error) {
+			if (error instanceof Error) {
+				setErrorMessage(error.message);
+			} else {
+				setErrorMessage("Could not load your group data.");
 			}
-		};
+		} finally {
+			setIsLoading(false);
+		}
+	};
 
-		fetchGroup();
+	useEffect(() => {
+		fetchData();
 	}, [apiService]);
+
+	const handleCopyInviteCode = () => {
+		if (group?.inviteCode) {
+			navigator.clipboard.writeText(group.inviteCode);
+			message.success("Invite code copied to clipboard!");
+		}
+	};
+
+	const handleRenameGroup = async () => {
+		if (!newGroupName.trim() || newGroupName === group?.name) {
+			setIsEditingName(false);
+			return;
+		}
+
+		setIsSubmitting(true);
+		try {
+			const updated = await apiService.put<Group>("/groups/me", { name: newGroupName });
+			setGroup(updated);
+			setIsEditingName(false);
+			message.success("Group renamed successfully!");
+		} catch (error) {
+			message.error("Failed to rename group.");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleRegenerateCode = () => {
+		Modal.confirm({
+			title: "Regenerate Invite Code?",
+			icon: <ExclamationCircleOutlined />,
+			content: "The old invite code will stop working immediately.",
+			okText: "Regenerate",
+			okType: "danger",
+			cancelText: "Cancel",
+			onOk: async () => {
+				try {
+					const updated = await apiService.post<Group>("/groups/me/invite-code", {});
+					setGroup(updated);
+					message.success("Invite code regenerated!");
+				} catch (error) {
+					message.error("Failed to regenerate code.");
+				}
+			},
+		});
+	};
+
+	const handleLeaveGroup = () => {
+		Modal.confirm({
+			title: "Leave group?",
+			icon: <LogoutOutlined className="text-red-500" />,
+			content: "You will lose access to the shared pantry and shopping list.",
+			okText: "Leave",
+			okType: "danger",
+			cancelText: "Cancel",
+			onOk: async () => {
+				try {
+					await apiService.delete("/groups/me/members/me");
+					message.success("You left the group.");
+					router.push("/groups");
+				} catch (error) {
+					message.error(error instanceof Error ? error.message : "Failed to leave group.");
+				}
+			},
+		});
+	};
+
+	const handleDeleteGroup = () => {
+		Modal.confirm({
+			title: "Delete group?",
+			icon: <DeleteOutlined className="text-red-500" />,
+			content: "This action is permanent. All group data will be erased.",
+			okText: "Delete",
+			okType: "danger",
+			cancelText: "Cancel",
+			onOk: async () => {
+				try {
+					await apiService.delete("/groups/me");
+					message.success("Group deleted.");
+					router.push("/groups");
+				} catch (error) {
+					message.error("Failed to delete group.");
+				}
+			},
+		});
+	};
 
 	return (
 		<div className="flex min-h-screen flex-col bg-gradient-to-b from-orange-50 to-white">
-			<PageHeader title="My Group" />
-			<div className="flex flex-1 items-center justify-center px-4 py-8">
+			<PageHeader title="Group Management" />
+			<div className="flex flex-1 flex-col items-center px-4 py-8">
 				<Card className="w-full max-w-2xl rounded-[2rem] border border-primary-500/20 bg-white/90 shadow-xl backdrop-blur">
-					<h1 className="mb-1 text-2xl font-semibold text-primary-600">Group information</h1>
-					<p className="mb-6 text-sm text-slate-500">Overview of the group you are currently part of.</p>
-
-					{joinedMessage ? <Alert className="mb-4" message={joinedMessage} showIcon type="success" /> : null}
+					{joinedMessage ? <Alert className="mb-6" message={joinedMessage} showIcon type="success" /> : null}
 
 					{isLoading ? (
-						<div className="flex items-center justify-center py-10">
-							<Spin size="large" />
+						<div className="flex items-center justify-center py-20">
+							<Spin size="large" tip="Loading group settings..." />
 						</div>
-					) : null}
-
-					{!isLoading && errorMessage ? <Alert message={errorMessage} showIcon type="error" /> : null}
-
-					{!isLoading && !errorMessage && group ? (
-						<div className="space-y-3 text-sm text-slate-700">
-							<div>
-								<span className="font-semibold text-slate-900">Name:</span> {group.name ?? "-"}
-							</div>
-							<div>
-								<span className="font-semibold text-slate-900">ID:</span> {group.id ?? "-"}
-							</div>
-							<div>
-								<span className="font-semibold text-slate-900">Invite code:</span> {group.inviteCode ?? "-"}
-							</div>
-							<div>
-								<span className="font-semibold text-slate-900">Created at:</span>{" "}
-								{group.createdAt ? new Date(group.createdAt).toLocaleString() : "-"}
-							</div>
-							<div>
-								<span className="font-semibold text-slate-900">Members:</span> {group.members?.length ?? 0}
-							</div>
-							{group.members && group.members.length > 0 ? (
-								<div className="mt-2 rounded-xl border border-primary-200 bg-primary-100 p-3">
-									<ul className="space-y-1">
-										{group.members.map((member, index) => (
-											<li key={`${member.id ?? member.userId ?? index}`}>
-												{member.username ?? member.name ?? member.userId ?? `Member ${index + 1}`}
-											</li>
-										))}
-									</ul>
+					) : errorMessage ? (
+						<div className="py-10 text-center">
+							<Alert message={errorMessage} showIcon type="error" />
+							<Button className="mt-4" onClick={() => router.push("/groups")}>
+								Return to Groups
+							</Button>
+						</div>
+					) : !group ? (
+						<div className="py-10 text-center">
+							<Title level={4}>No group found</Title>
+							<Button className="mt-4 pm-button" onClick={() => router.push("/groups")}>
+								Join or Create a Group
+							</Button>
+						</div>
+					) : (
+						<div className="space-y-6">
+							<div className="flex items-center justify-between">
+								<div className="flex-1">
+									{isEditingName ? (
+										<Space.Compact className="w-full max-w-md">
+											<Input
+												value={newGroupName}
+												onChange={(e) => setNewGroupName(e.target.value)}
+												onPressEnter={handleRenameGroup}
+												autoFocus
+											/>
+											<Button loading={isSubmitting} onClick={handleRenameGroup} type="primary">
+												Save
+											</Button>
+											<Button onClick={() => setIsEditingName(false)}>Cancel</Button>
+										</Space.Compact>
+									) : (
+										<div className="flex items-center gap-3">
+											<Title className="!mb-0 !text-primary-600" level={2}>
+												{group.name}
+											</Title>
+											{isAdmin && (
+												<Tooltip title="Rename Group">
+													<Button
+														icon={<EditOutlined />}
+														onClick={() => setIsEditingName(true)}
+														type="text"
+													/>
+												</Tooltip>
+											)}
+										</div>
+									)}
+									<Text className="text-secondary-600" type="secondary">
+										Created on {group.createdAt ? new Date(group.createdAt).toLocaleDateString() : "-"}
+									</Text>
 								</div>
-							) : null}
+								{isAdmin ? (
+									<Tag className="rounded-full px-3 py-1 font-semibold" color="gold">
+										Admin Access
+									</Tag>
+								) : (
+									<Tag className="rounded-full px-3 py-1 font-semibold" color="blue">
+										Member
+									</Tag>
+								)}
+							</div>
+
+							<Divider className="my-2" />
+
+							<div className="rounded-2xl bg-slate-50 p-6">
+								<div className="mb-4 flex items-center justify-between">
+									<div>
+										<Text className="block font-semibold text-slate-900">Invite Code</Text>
+										<Text className="text-xs text-slate-500">Share this code with your teammates.</Text>
+									</div>
+									<div className="flex items-center gap-2">
+										<div className="flex h-10 items-center justify-center rounded-lg border border-primary-200 bg-white px-4 font-mono text-lg font-bold tracking-widest text-primary-600">
+											{group.inviteCode}
+										</div>
+										<Tooltip title="Copy Code">
+											<Button icon={<CopyOutlined />} onClick={handleCopyInviteCode} />
+										</Tooltip>
+										{isAdmin && (
+											<Tooltip title="Regenerate Code">
+												<Button icon={<ReloadOutlined />} onClick={handleRegenerateCode} />
+											</Tooltip>
+										)}
+									</div>
+								</div>
+							</div>
+
+							<div>
+								<div className="mb-3 flex items-center gap-2">
+									<UserOutlined className="text-primary-600" />
+									<Text className="text-lg font-semibold">Members ({group.members?.length ?? 0})</Text>
+								</div>
+								<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+									{group.members?.map((member) => (
+										<div
+											key={member.userID}
+											className={`flex items-center justify-between rounded-xl border p-3 ${
+												member.userID === currentUser?.id
+													? "border-primary-300 bg-primary-50"
+													: "border-slate-100 bg-white"
+											}`}
+										>
+											<div className="flex items-center gap-2">
+												<div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200">
+													<UserOutlined className="text-slate-500" />
+												</div>
+												<div>
+													<Text className="block font-medium">
+														{member.username} {member.userID === currentUser?.id && "(You)"}
+													</Text>
+													{member.joinedAt && (
+														<Text className="text-[10px]" type="secondary">
+															Joined {new Date(member.joinedAt).toLocaleDateString()}
+														</Text>
+													)}
+												</div>
+											</div>
+											{member.role === GroupRole.ADMIN && (
+												<Tag className="m-0 text-[10px]" color="orange">
+													Admin
+												</Tag>
+											)}
+										</div>
+									))}
+								</div>
+							</div>
+
+							<Divider />
+
+							<div className="flex flex-wrap items-center justify-between gap-4">
+								<div className="flex items-center gap-2">
+									<InfoCircleOutlined className="text-slate-400" />
+									<Text className="text-xs text-slate-500">
+										You are viewing the management dashboard for {group.name}.
+									</Text>
+								</div>
+								<div className="flex gap-2">
+									<Button
+										className="border-red-200 text-red-500 hover:border-red-500 hover:bg-red-50"
+										icon={<LogoutOutlined />}
+										onClick={handleLeaveGroup}
+									>
+										Leave Group
+									</Button>
+									{isAdmin && (
+										<Button danger icon={<DeleteOutlined />} onClick={handleDeleteGroup} type="primary">
+											Delete Group
+										</Button>
+									)}
+								</div>
+							</div>
 						</div>
-					) : null}
+					)}
 				</Card>
 			</div>
 		</div>

--- a/app/groups/me/page.tsx
+++ b/app/groups/me/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@ant-design/icons";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
-import PageHeader from "@/components/page-header";
+import DashboardShell from "@/components/dashboard-shell";
 import { Group, GroupRole } from "@/types/group";
 import { User } from "@/types/user";
 
@@ -156,9 +156,8 @@ export default function GroupMePage() {
 	};
 
 	return (
-		<div className="flex min-h-screen flex-col bg-gradient-to-b from-orange-50 to-white">
-			<PageHeader title="Group Management" />
-			<div className="flex flex-1 flex-col items-center px-4 py-8">
+		<DashboardShell headerTitle="Group Management" selectedMenuKey="6">
+			<div className="flex flex-col items-center">
 				<Card className="w-full max-w-2xl rounded-[2rem] border border-primary-500/20 bg-white/90 shadow-xl backdrop-blur">
 					{joinedMessage ? <Alert className="mb-6" message={joinedMessage} showIcon type="success" /> : null}
 
@@ -320,7 +319,7 @@ export default function GroupMePage() {
 					)}
 				</Card>
 			</div>
-		</div>
+		</DashboardShell>
 	);
 }
 

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -38,7 +38,7 @@ const GroupsPage: React.FC = () => {
 			try {
 				const group = await apiService.get<GroupGetDTO>("/groups/me");
 				setExistingGroup(group);
-			} catch (error) {
+			} catch {
 				setExistingGroup(null);
 			} finally {
 				setIsLoading(false);

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
-import { Alert, Button, Card, Form, Input } from "antd";
+import { Alert, Button, Card, Form, Input, Spin } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
 import { useRouter } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import PageHeader from "@/components/page-header";
@@ -28,6 +29,23 @@ const GroupsPage: React.FC = () => {
 	const [successMessage, setSuccessMessage] = useState<string>("");
 	const [errorMessage, setErrorMessage] = useState<string>("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [existingGroup, setExistingGroup] = useState<GroupGetDTO | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+
+	React.useEffect(() => {
+		const checkMembership = async () => {
+			setIsLoading(true);
+			try {
+				const group = await apiService.get<GroupGetDTO>("/groups/me");
+				setExistingGroup(group);
+			} catch (error) {
+				setExistingGroup(null);
+			} finally {
+				setIsLoading(false);
+			}
+		};
+		checkMembership();
+	}, [apiService]);
 
 	const handleCreateGroup = async (values: CreateGroupFormValues) => {
 		setErrorMessage("");
@@ -77,24 +95,44 @@ const GroupsPage: React.FC = () => {
 		}
 	};
 
-	const handleLeaveGroup = async () => {
-		setErrorMessage("");
-		setSuccessMessage("");
-		setIsSubmitting(true);
+	if (isLoading) {
+		return (
+			<div className="flex min-h-screen flex-col bg-gradient-to-b from-orange-50 to-white">
+				<PageHeader title="Groups" />
+				<div className="flex flex-1 items-center justify-center">
+					<Spin size="large" />
+				</div>
+			</div>
+		);
+	}
 
-		try {
-			await apiService.delete<void>("/groups/me/members/me");
-			setSuccessMessage("You left the group.");
-		} catch (error) {
-			if (error instanceof Error) {
-				setErrorMessage(error.message);
-			} else {
-				setErrorMessage("An unknown error occurred while leaving the group.");
-			}
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
+	if (existingGroup) {
+		return (
+			<div className="flex min-h-screen flex-col bg-gradient-to-b from-orange-50 to-white">
+				<PageHeader title="Groups" />
+				<div className="flex flex-1 items-center justify-center px-4 py-8">
+					<Card className="w-full max-w-md rounded-[2rem] border border-primary-500/20 bg-white/90 p-8 text-center shadow-xl backdrop-blur">
+						<div className="mb-6 flex justify-center">
+							<div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary-100">
+								<InfoCircleOutlined className="text-3xl text-primary-600" />
+							</div>
+						</div>
+						<h1 className="mb-2 text-2xl font-semibold text-primary-600">Already in a group</h1>
+						<p className="mb-8 text-secondary-600">
+							You are currently a member of <span className="font-bold text-slate-900">{existingGroup.name}</span>.
+							Leave your current group if you want to join or create a new one.
+						</p>
+						<Button
+							className="pm-button !h-12 w-full !text-lg !font-semibold"
+							onClick={() => router.push("/groups/me")}
+						>
+							Manage Your Group
+						</Button>
+					</Card>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="flex min-h-screen flex-col bg-gradient-to-b from-orange-50 to-white">
@@ -171,17 +209,6 @@ const GroupsPage: React.FC = () => {
 								</Button>
 							</Form.Item>
 						</Form>
-
-						<div className="mt-6 border-t border-primary-200 pt-4">
-							<p className="mb-3 text-sm text-secondary-700">Already in a group?</p>
-							<Button
-								className="register-button !h-11 !font-semibold"
-								loading={isSubmitting}
-								onClick={handleLeaveGroup}
-							>
-								Leave group
-							</Button>
-						</div>
 					</Card>
 				</div>
 			</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
 			<div className="flex min-h-screen items-center justify-center px-4 py-10">
 				<div className="text-center">
 					<h1 className="text-4xl font-bold text-primary-600">Welcome to PlateMate!</h1>
-					<p className="mt-4 text-lg text-accent-500">Your ultimate recipe companion.</p>
+					<p className="mt-4 text-lg text-accent-500">Your ultimate kitchen assistant for pantry and shopping list management.</p>
 				</div>
 			</div>
 		</div>

--- a/app/pantry/page.tsx
+++ b/app/pantry/page.tsx
@@ -119,7 +119,11 @@ const PantryPage: React.FC = () => {
 				const data = await apiService.get<PantryGetDTO>("/groups/me/pantry");
 				setPantry(data);
 			} catch (error) {
-				if (error instanceof Error) {
+				// If status is 404, it likely means no group, which is an expected "Individual" state now.
+				if (error && typeof error === "object" && "status" in error && error.status === 404) {
+					console.debug("No pantry found - user likely not in a group.");
+					setPantry(null);
+				} else if (error instanceof Error) {
 					setErrorMessage(error.message);
 				} else {
 					setErrorMessage("Could not load the pantry.");
@@ -472,7 +476,7 @@ const PantryPage: React.FC = () => {
 						columns={columns}
 						dataSource={items}
 						pagination={{ pageSize: 8 }}
-						rowKey={(record, index) => `${record.id ?? "temp"}-${index}`}
+						rowKey={(record) => record.id ?? `temp-${record.ingredientId}`}
 					/>
 				)}
 			</Card>

--- a/app/shopping-lists/page.tsx
+++ b/app/shopping-lists/page.tsx
@@ -99,7 +99,11 @@ const ShoppingListsPage: React.FC = () => {
 				const data = await apiService.get<ShoppingListGetDTO>("/groups/me/shopping-list");
 				setShoppingList(data);
 			} catch (error) {
-				if (error instanceof Error) {
+				// If status is 404, it likely means no group, which is an expected "Individual" state now.
+				if (error && typeof error === "object" && "status" in error && error.status === 404) {
+					console.debug("No shopping list found - user likely not in a group.");
+					setShoppingList(null);
+				} else if (error instanceof Error) {
 					setErrorMessage(error.message);
 				} else {
 					setErrorMessage("Could not load the shopping list.");
@@ -504,7 +508,7 @@ const ShoppingListsPage: React.FC = () => {
 						columns={columns}
 						dataSource={items}
 						pagination={{ pageSize: 8 }}
-						rowKey={(record, index) => `${record.id ?? "temp"}-${index}`}
+						rowKey={(record) => record.id ?? `temp-${record.ingredientId}`}
 					/>
 				)}
 			</Card>

--- a/app/types/group.ts
+++ b/app/types/group.ts
@@ -1,0 +1,19 @@
+export enum GroupRole {
+	ADMIN = "ADMIN",
+	MEMBER = "MEMBER",
+}
+
+export interface GroupMember {
+	userID?: string;
+	username?: string;
+	role?: GroupRole;
+	joinedAt?: string;
+}
+
+export interface Group {
+	id?: number;
+	name?: string;
+	inviteCode?: string;
+	createdAt?: string;
+	members?: GroupMember[];
+}


### PR DESCRIPTION
**Group management changes**
- Added the page for managing the group (using Admin role)
- Added UI for renaming groups, regenerating invite codes, and deleting groups (all protected by confirmation modals)
- Added a "Leave Group" feature for non-admin members
- The app now automatically detects if you are in a group and redirects you from the "Join/Create" page directly to your management dashboard

**Dashboard**
- The Dashboard now displays actual name, total Pantry stock and remaining Shopping List items

**Navigation**
- Made the header clickable (with dashboard as the default page)
- Removed Recipes section (as it seems out of scope now)

+ addressed Ant Design Fixes 
+ updated Landing page message
